### PR TITLE
Fix bundling issue for purescript v0.13.3

### DIFF
--- a/src/React/Redux.js
+++ b/src/React/Redux.js
@@ -12,11 +12,12 @@ exports.reduxApplyMiddleware = function reduxApplyMiddleware(middleware){
   return Redux.applyMiddleware.apply(Redux, middleware);
 };
 
-exports.reduxConnect = function reduxConnect(mapStateToProps, mapDispatchToProps, mergeProps, options){
+var reduxConnect = function reduxConnect(mapStateToProps, mapDispatchToProps, mergeProps, options){
   return ReactRedux.connect(mapStateToProps, mapDispatchToProps, mergeProps, options);
 };
 
-exports.reduxConnect_ = exports.reduxConnect;
+exports.reduxConnect = reduxConnect;
+exports.reduxConnect_ = reduxConnect;
 
 exports.reduxProviderClass = ReactRedux.Provider;
 


### PR DESCRIPTION
After updating to v0.13.3 from v0.13.2, we noticed that, when bundling was enabled, we'd get "r.reduxConnect_ is not a function", and the value of `r.reduxConnect_` was undefined. This was caused because after bundling, the statement `exports.reduxConnect = function reduxConnect ...` was optimized away, since it is directly assigned to `exports.reduxConnect` and the compiler probably can't figure out that it is used later on. By first assigning the function to a variable and then explicitly assigning the exports, the problem is fixed.